### PR TITLE
Added merge/split tests

### DIFF
--- a/tobac/__init__.py
+++ b/tobac/__init__.py
@@ -74,6 +74,7 @@ from .feature_detection import feature_detection_multithreshold
 from .tracking import linking_trackpy
 from .wrapper import maketrack
 from .wrapper import tracking_wrapper
+from . import merge_split
 
 # Set version number
 __version__ = "1.4.0"

--- a/tobac/merge_split.py
+++ b/tobac/merge_split.py
@@ -160,7 +160,7 @@ def merge_split_cells(TRACK, dxy, distance=25000, frame_len=5):
 
     cell_parent_track_id = []
 
-    for i, id in enumerate(track_id, start=-1):
+    for i, id in enumerate(track_id, start=0):
         if len(track_id[int(id)]) == 1:
             cell_parent_track_id.append(int(i))
 

--- a/tobac/tests/test_merge_split.py
+++ b/tobac/tests/test_merge_split.py
@@ -92,5 +92,3 @@ def test_merge_split_cells():
     # These cells should NOT have merged together.
     print(mergesplit_output_unmerged["track"])
     assert len(mergesplit_output_unmerged["track"]) == 2
-
-    pass

--- a/tobac/tests/test_merge_split.py
+++ b/tobac/tests/test_merge_split.py
@@ -1,0 +1,96 @@
+"""Module to test tobac.merge_split
+"""
+
+import pandas as pd
+import numpy as np
+
+import datetime
+
+import tobac.testing as tbtest
+import tobac.tracking as tbtrack
+import tobac.merge_split as mergesplit
+
+
+def test_merge_split_cells():
+    """Tests tobac.merge_split.merge_split_cells by
+    generating two cells, colliding them into one another,
+    and merging them.
+    """
+
+    cell_1 = tbtest.generate_single_feature(
+        1,
+        1,
+        min_h1=0,
+        max_h1=100,
+        min_h2=0,
+        max_h2=100,
+        frame_start=0,
+        num_frames=2,
+        spd_h1=20,
+        spd_h2=20,
+        start_date=datetime.datetime(2022, 1, 1, 0),
+    )
+    cell_1["feature"] = [1, 3]
+
+    cell_2 = tbtest.generate_single_feature(
+        1,
+        100,
+        min_h1=0,
+        max_h1=100,
+        min_h2=0,
+        max_h2=100,
+        frame_start=0,
+        num_frames=2,
+        spd_h1=20,
+        spd_h2=-20,
+        start_date=datetime.datetime(2022, 1, 1, 0),
+    )
+    cell_2["feature"] = [2, 4]
+    cell_3 = tbtest.generate_single_feature(
+        30,
+        50,
+        min_h1=0,
+        max_h1=100,
+        min_h2=0,
+        max_h2=100,
+        frame_start=2,
+        num_frames=2,
+        spd_h1=20,
+        spd_h2=0,
+        start_date=datetime.datetime(2022, 1, 1, 0, 10),
+    )
+    cell_3["feature"] = [5, 6]
+    features = pd.concat([cell_1, cell_2, cell_3])
+    output = tbtrack.linking_trackpy(features, None, 1, 1, v_max=40)
+
+    dist_between = np.sqrt(
+        np.power(
+            output[output["frame"] == 1].iloc[0]["hdim_1"]
+            - output[output["frame"] == 1].iloc[1]["hdim_1"],
+            2,
+        )
+        + np.power(
+            output[output["frame"] == 1].iloc[0]["hdim_2"]
+            - output[output["frame"] == 1].iloc[1]["hdim_2"],
+            2,
+        )
+    )
+
+    # Test a successful merger
+    mergesplit_output_merged = mergesplit.merge_split_cells(
+        output, dxy=1, distance=dist_between + 50
+    )
+
+    # These cells should have merged together.
+    assert len(mergesplit_output_merged["track"]) == 1
+
+    # Test an unsuccessful merger.
+    mergesplit_output_unmerged = mergesplit.merge_split_cells(
+        output, dxy=1, distance=dist_between - 50
+    )
+
+    # These cells should NOT have merged together.
+    print(mergesplit_output_unmerged["track"])
+    assert len(mergesplit_output_unmerged["track"]) == 2
+
+    pass


### PR DESCRIPTION
The main purpose of this PR is to add merge/split tests, but I've also done a couple other things. 

First, I've imported `merge_split` in the main `__init__.py`, which both builds the documentation and allows users to `import tobac` and then run `tobac.merge_split` instead of having to `import tobac.merge_split` explicitly. 

Second, I've changed the default start track number to `0` from `-1`. I think this caused a great deal of confusion over on the main PR, and threw me for a loop while building the test.

Third, I've added a test that merges two cells and checks to make sure that they are merged (with an appropriate distance set) or not merged (with a distance set too close). I think that this gets us most of the way there on tests, if not all of the way there. I think a figure would help us out with the documentation, and I'm working on that now. 

@kelcyno, I'd love to hear your feedback. I'm happy to send along the notebook that I used to create the test. The idea and some of the code for this test comes from @JuliaKukulies and @snilsn.